### PR TITLE
Do not set system look and feel if using GTK.

### DIFF
--- a/src/main/App.java
+++ b/src/main/App.java
@@ -66,7 +66,10 @@ public class App {
 
     private App() {
         try {
-            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+            String systemLookAndFeel = UIManager.getSystemLookAndFeelClassName();
+            if (!systemLookAndFeel.equals("com.sun.java.swing.plaf.gtk.GTKLookAndFeel")) {
+                UIManager.setLookAndFeel(systemLookAndFeel);
+            }
         } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | UnsupportedLookAndFeelException ex) {
             try {
                 UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());


### PR DESCRIPTION
There is a longstanding bug with the OptionPane icons when in Linux, specifically related to attempting to get them while having the look and feel set to GTK. See: https://community.oracle.com/tech/developers/discussion/1359028/uimanager-geticon-optionpane-warningicon-on-linux.

This results in a null pointer exception on the calls
`combWarningButton.setIcon(AppImage.getScaledIcon(AppImage.UI_WARNING, 16, 16));
timeWarningButton.setIcon(AppImage.getScaledIcon(AppImage.UI_WARNING, 16, 16));`
in MainFrame.java.